### PR TITLE
allow setting subprocess timeout via env var

### DIFF
--- a/django_concurrent_tests/helpers.py
+++ b/django_concurrent_tests/helpers.py
@@ -53,4 +53,6 @@ def make_concurrent_calls(*calls):
         )
     pool.close()
     pool.join()
-    return [result.get(timeout=SUBPROCESS_TIMEOUT + 5) for result in results]
+    # add a bit of extra timeout to allow process terminate cleanup to run
+    # (because we also have an inner timeout on our ProcessManager thread join)
+    return [result.get(timeout=SUBPROCESS_TIMEOUT + 2) for result in results]

--- a/django_concurrent_tests/helpers.py
+++ b/django_concurrent_tests/helpers.py
@@ -1,6 +1,6 @@
 from multiprocessing.pool import ThreadPool as Pool
 
-from .utils import test_call
+from .utils import test_call, SUBPROCESS_TIMEOUT
 
 
 def call_concurrently(concurrency, function, **kwargs):
@@ -53,4 +53,4 @@ def make_concurrent_calls(*calls):
         )
     pool.close()
     pool.join()
-    return [result.get(timeout=30) for result in results]
+    return [result.get(timeout=SUBPROCESS_TIMEOUT + 5) for result in results]

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ class Tox(TestCommand):
 
 setup(
     name='django-concurrent-test-helper',
-    version='0.2.7',
+    version='0.2.8',
     description="Helpers for executing Django app code concurrently within Django tests",
     long_description=open('README.rst').read(),
     author="Anentropic",

--- a/testing/tests/funcs_to_test.py
+++ b/testing/tests/funcs_to_test.py
@@ -38,3 +38,8 @@ def raise_exception():
 @badly_decorated
 def wallpaper(colour):
     return '%s stripes' % colour
+
+
+def timeout(sleep_for):
+    sleep(sleep_for)
+    return sleep_for

--- a/testing/tests/helpers_test.py
+++ b/testing/tests/helpers_test.py
@@ -3,6 +3,7 @@ from pprint import pprint
 import pytest
 
 from django_concurrent_tests.helpers import call_concurrently
+from django_concurrent_tests.utils import SUBPROCESS_TIMEOUT, TerminatedProcessError
 from flaky import flaky
 
 from testapp.models import Semaphore
@@ -13,6 +14,7 @@ from .funcs_to_test import (
     raise_exception,
     wallpaper,
     CustomError,
+    timeout,
 )
 
 
@@ -84,3 +86,11 @@ def test_badly_decorated_pass():
 
     for result in results:
         assert result == 'orange stripes'
+
+
+def test_timeout():
+    results = call_concurrently(1, timeout, sleep_for=SUBPROCESS_TIMEOUT + 5)
+    pprint([str(r) for r in results])
+
+    for result in results:
+        assert isinstance(result, TerminatedProcessError)

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ setenv =
     py{32,33,34}-dj17: DJANGO_SETTINGS_MODULE=py3-dj17_testproject.settings
     py{32,33,34,35}-dj18: DJANGO_SETTINGS_MODULE=py3-dj18_testproject.settings
     py{34,35}-dj19: DJANGO_SETTINGS_MODULE=py3-dj19_testproject.settings
+    DJANGO_CONCURRENT_TESTS_TIMEOUT=10
 deps =
     pytest==2.9.2
     pytest-django==2.9
@@ -44,5 +45,6 @@ deps =
     dj17: django==1.7
     dj18: django>1.8.3,<1.9
     dj19: django==1.9
+    ipdb
 
-commands = py.test {toxinidir}/testing/tests -v
+commands = py.test -v -s {toxinidir}/testing/tests


### PR DESCRIPTION
also, report timeout as a named exception (instead of just returning None)