### PR TITLE
handle (and wrap) errors during deserialization

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,8 @@ Note that if your called function raises an exception, the exception will be wra
 
 .. code:: python
 
+    import types
+
     from django_concurrent_tests.errors import WrappedError
     from django_concurrent_tests.helpers import make_concurrent_calls
 
@@ -103,14 +105,23 @@ Note that if your called function raises an exception, the exception will be wra
 
         assert isinstance(errors[0], WrappedError)
         assert isinstance(errors[0].error, ValueError)  # the original error
+        assert isinstance(errors[0].traceback, types.TracebackType)
 
-        import traceback
-        traceback.print_tb(errors[0].traceback)
-        
-        try:
-            errors[0].reraise()
-        except ValueError as e:
-            # `e` will be the original error with original traceback
+    # other things you can do with the WrappedError:
+
+    # 1. print the traceback
+    errors[0].print_tb()
+
+    # 2. drop into a debugger (ipdb if installed, else pdb)
+    errors[0].debug()
+    ipdb> 
+    # ...can explore the stack of original exception!
+    
+    # 3. re-raise the original exception
+    try:
+        errors[0].reraise()
+    except ValueError as e:
+        # `e` will be the original error with original traceback
 
 Another thing to remember is if you are using the ``override_settings`` decorator in your test. You need to also decorate your called functions (since the subprocesses won't see the overridden settings from your main test process):
 

--- a/django_concurrent_tests/errors.py
+++ b/django_concurrent_tests/errors.py
@@ -1,4 +1,5 @@
 import sys
+import traceback
 
 import six
 import tblib.pickling_support
@@ -23,6 +24,12 @@ class WrappedError(Exception):
             wrapped = WrappedError(e)
 
         wrapped.reraise()
+
+    Or drop into a debugger:
+
+        wrapped.debug()
+        ipdb> 
+        ... can explore the stack of original exception!
     """
 
     def __init__(self, error):
@@ -32,3 +39,14 @@ class WrappedError(Exception):
 
     def reraise(self):
         six.reraise(self.error, None, self.traceback)
+
+    def print_tb(self):
+        traceback.print_tb(self.traceback)
+
+    def debug(self):
+        try:
+            import ipdb
+            ipdb.post_mortem(self.traceback)
+        except ImportError:
+            import pdb
+            pdb.post_mortem(self.traceback)

--- a/django_concurrent_tests/utils.py
+++ b/django_concurrent_tests/utils.py
@@ -104,12 +104,12 @@ def test_call(f, **kwargs):
                 function_path,
                 kwargs=serialized_kwargs,
             )
+        # deserialize the result from subprocess run
+        # (any error raised when running the concurrent func will be stored in `result`)
+        return b64pickle.loads(result) if result else None
     except Exception as e:
         # handle any errors which occurred during setup of subprocess
         return errors.WrappedError(e)
-    # deserialize the result from subprocess run
-    # (any error raised when running the concurrent func will be stored in `result`)
-    return b64pickle.loads(result) if result else None
 
 
 @contextmanager

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
     install_requires=[
         'six',
         'tblib',
+        'mock',
     ],
     tests_require=[
         'tox>=1.8',

--- a/testing/tests/funcs_to_test.py
+++ b/testing/tests/funcs_to_test.py
@@ -6,6 +6,10 @@ from testapp.decorators import badly_decorated
 from testapp.models import Semaphore
 
 
+def simple():
+    return True
+
+
 def update_count_naive(id_):
     try:
         obj = Semaphore.objects.get(pk=id_, locked=False)

--- a/testing/tests/helpers_test.py
+++ b/testing/tests/helpers_test.py
@@ -18,18 +18,25 @@ from django_concurrent_tests.utils import (
 from testapp.models import Semaphore
 
 from .funcs_to_test import (
+    CustomError,
+    environment,
+    raise_exception,
+    simple,
+    timeout,
     update_count_naive,
     update_count_transactional,
-    raise_exception,
     wallpaper,
-    CustomError,
-    timeout,
-    environment,
 )
 
 
 def is_success(result):
     return result is True and not isinstance(result, Exception)
+
+
+def test_simple():
+    concurrency = 2
+    results = call_concurrently(concurrency, simple)
+    assert results == [True, True]
 
 
 @flaky(max_runs=3, min_passes=1)

--- a/testing/tests/utils_test.py
+++ b/testing/tests/utils_test.py
@@ -1,6 +1,13 @@
 import os
 
-from django_concurrent_tests.utils import override_environment
+import mock
+import pytest
+
+from django_concurrent_tests.errors import WrappedError
+from django_concurrent_tests.utils import override_environment, test_call as call_func
+# if we import as `test_call` pytest thinks it's a test :facepalm:
+
+from .funcs_to_test import simple
 
 
 def test_override_environment():
@@ -20,3 +27,18 @@ def test_override_environment():
     assert os.getenv('TEST_VALUE1') == 'val1'
     assert os.getenv('TEST_VALUE2') == 'val2'
     assert os.getenv('TEST_VALUE3') is None
+
+
+def test_deserializer_exception():
+    """
+    Exceptions raised when deserializing result from subprocess are wrapped
+    with WrappedError, providing access to the original error and traceback.
+    """
+    with mock.patch(
+        'django_concurrent_tests.b64pickle.loads', side_effect=ValueError('WTF')
+    ) as mock_loads:
+        result = call_func(simple)
+    
+    assert isinstance(result, WrappedError)
+    assert isinstance(result.error, ValueError)
+    assert result.error.args == ('WTF',)

--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,7 @@ deps =
     flaky==3.0
     pytz
     six
+    mock
     tblib
     dj14: django==1.4
     dj15: django==1.5


### PR DESCRIPTION
also adds nifty debug helper to WrappedError