### PR TITLE
rename test_call func

### DIFF
--- a/django_concurrent_tests/helpers.py
+++ b/django_concurrent_tests/helpers.py
@@ -2,7 +2,7 @@ from multiprocessing.pool import ThreadPool as Pool
 
 import six
 
-from .utils import test_call, SUBPROCESS_TIMEOUT
+from .utils import run_in_subprocess, SUBPROCESS_TIMEOUT
 
 
 def call_concurrently(concurrency, function, **kwargs):
@@ -51,7 +51,7 @@ def make_concurrent_calls(*calls):
     futures = []
     for func, kwargs in calls:
         futures.append(
-            pool.apply_async(test_call, args=(func,), kwds=kwargs)
+            pool.apply_async(run_in_subprocess, args=(func,), kwds=kwargs)
         )
     pool.close()
     pool.join()

--- a/django_concurrent_tests/utils.py
+++ b/django_concurrent_tests/utils.py
@@ -68,7 +68,7 @@ class ProcessManager(object):
         return self.stdout
 
 
-def test_call(f, **kwargs):
+def run_in_subprocess(f, **kwargs):
     """
     Args:
         f (Union[function, str]): the function to call, or

--- a/testing/tests/utils_test.py
+++ b/testing/tests/utils_test.py
@@ -6,10 +6,9 @@ import pytest
 from django_concurrent_tests.errors import WrappedError
 from django_concurrent_tests.utils import (
     override_environment,
-    test_call as call_func,
+    run_in_subprocess,
     ProcessManager,
 )
-# if we import as `test_call` pytest thinks it's a test :facepalm:
 
 from .funcs_to_test import simple
 
@@ -41,7 +40,7 @@ def test_deserializer_exception():
     with mock.patch(
         'django_concurrent_tests.b64pickle.loads', side_effect=ValueError('WTF')
     ) as mock_loads:
-        result = call_func(simple)
+        result = run_in_subprocess(simple)
     
     assert isinstance(result, WrappedError)
     assert isinstance(result.error, ValueError)


### PR DESCRIPTION
`test_call` was a stupid name, and creates problems if you want to import it somewhere visible to test runners (they think it's a test case)