### PR TITLE
Better handling for error when unpickling subprocess result

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ tag:
 	git push --tags
 
 test:
+	# assumes Python 2.7 virtualenv with some version of Django installed
 	PYTHONPATH=.:testing:testing/tests:testing/tests/py2-dj$$(django-admin --version | tr -d .)_testproject \
 	DJANGO_SETTINGS_MODULE=py2-dj$$(django-admin --version | tr -d .)_testproject.settings \
 	DJANGO_CONCURRENT_TESTS_TIMEOUT=10 \
-	py.test -v -s -pdb testing/tests
+	py.test -v -s --pdb --pdbcls=IPython.terminal.debugger:TerminalPdb testing/tests

--- a/django_concurrent_tests/__about__.py
+++ b/django_concurrent_tests/__about__.py
@@ -1,4 +1,4 @@
-__version__ = '0.5.2'
+__version__ = '0.6.0'
 
 
 if __name__ == '__main__':

--- a/django_concurrent_tests/b64pickle.py
+++ b/django_concurrent_tests/b64pickle.py
@@ -33,14 +33,22 @@ def loads(val):
     try:
         return pickle.loads(val)
     except Exception as e:
+        str_val = val.decode('ascii')
         # we can still recover some useful information from the still-pickled
         # value... take the first part of the content, this should show
         # the wrapped error in raw form, before the long traceback section
-        summary = '{}...'.format(val[:val.index('unpickle_traceback') + 18])
+        if 'unpickle_traceback' in str_val:
+            truncate_to = str_val.index('unpickle_traceback') + len('unpickle_traceback')
+        else:
+            truncate_to = 300
+        summary = '{truncated}{ellipsis}'.format(
+            truncated=str_val[:truncate_to],
+            ellipsis='...' if len(str_val) > truncate_to else ''
+        )
         # `summary` will be printed when you `repr(error)` hopefully giving
-        # some hints what was wrong immediately
+        # some hints about what was wrong
         error = PickleLoadsError(e, summary)
         # attach the full still-pickled value to allow detailed introspection
         # in case of failure
-        error.pickled_value = val
+        error.pickled_value = str_val
         raise error

--- a/django_concurrent_tests/b64pickle.py
+++ b/django_concurrent_tests/b64pickle.py
@@ -13,6 +13,10 @@ http://bugs.python.org/issue2980
 """
 
 
+class PickleLoadsError(Exception):
+    pass
+
+
 def dumps(obj):
     encoded = b64encode(pickle.dumps(obj, protocol=0))
     if six.PY3:
@@ -25,4 +29,18 @@ def loads(val):
     if six.PY3 and not isinstance(val, six.binary_type):
         # Python 3.2 requires a bytestring, later Py3s don't care
         val = bytes(val, encoding='ascii')
-    return pickle.loads(b64decode(val))
+    val = b64decode(val)
+    try:
+        return pickle.loads(val)
+    except Exception as e:
+        # we can still recover some useful information from the still-pickled
+        # value... take the first part of the content, this should show
+        # the wrapped error in raw form, before the long traceback section
+        summary = '{}...'.format(val[:val.index('unpickle_traceback') + 18])
+        # `summary` will be printed when you `repr(error)` hopefully giving
+        # some hints what was wrong immediately
+        error = PickleLoadsError(e, summary)
+        # attach the full still-pickled value to allow detailed introspection
+        # in case of failure
+        error.pickled_value = val
+        raise error

--- a/django_concurrent_tests/errors.py
+++ b/django_concurrent_tests/errors.py
@@ -28,14 +28,14 @@ class WrappedError(Exception):
     Or drop into a debugger:
 
         wrapped.debug()
-        ipdb> 
+        ipdb>
         ... can explore the stack of original exception!
     """
 
     def __init__(self, error):
         self.error = error
         __,  __, self.traceback = sys.exc_info()
-        super(WrappedError, self).__init__(str(error))
+        super(WrappedError, self).__init__(repr(error))
 
     def reraise(self):
         six.reraise(self.error, None, self.traceback)

--- a/django_concurrent_tests/helpers.py
+++ b/django_concurrent_tests/helpers.py
@@ -1,7 +1,5 @@
 from multiprocessing.pool import ThreadPool as Pool
 
-import six
-
 from .utils import run_in_subprocess, SUBPROCESS_TIMEOUT
 
 

--- a/django_concurrent_tests/management/commands/concurrent_call_wrapper.py
+++ b/django_concurrent_tests/management/commands/concurrent_call_wrapper.py
@@ -214,7 +214,7 @@ class Command(BaseCommand):
                 # ensure we're using test dbs, shared with parent test run
                 if not kwargs['no_test_db']:
                     use_test_databases()
- 
+
                 result = f(**f_kwargs)
 
                 close_db_connections()

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
-pytest==4.4.1
-pytest-django==3.4.8
+pytest==3.10.1
+pytest-django==2.9
 flaky==3.5.3
 pytz
 six

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,10 @@
+pytest==4.4.1
+pytest-django==3.4.8
+flaky==3.5.3
+pytz
+six
+mock
+tblib
+ipython
+ipdb
+# and pick a version of Django :)

--- a/tox.ini
+++ b/tox.ini
@@ -42,8 +42,8 @@ setenv =
     py{34,35,36}-dj111: DJANGO_SETTINGS_MODULE=py3-dj111_testproject.settings
     DJANGO_CONCURRENT_TESTS_TIMEOUT=10
 deps =
-    pytest==4.4.1
-    pytest-django==3.4.8
+    pytest==3.10.1
+    pytest-django==2.9
     flaky==3.5.3
     pytz
     six

--- a/tox.ini
+++ b/tox.ini
@@ -42,9 +42,9 @@ setenv =
     py{34,35,36}-dj111: DJANGO_SETTINGS_MODULE=py3-dj111_testproject.settings
     DJANGO_CONCURRENT_TESTS_TIMEOUT=10
 deps =
-    pytest==2.9.2
-    pytest-django==2.9
-    flaky==3.0
+    pytest==4.4.1
+    pytest-django==3.4.8
+    flaky==3.5.3
     pytz
     six
     mock


### PR DESCRIPTION
without this fix, what you get back is an unhelpful `RuntimeError("Cannot re-create traceback !")`

with the fix you can see something like:
```
PickleLoadsError(RuntimeError(\'Cannot re-create traceback !\',),
\'cdjango_concurrent_tests.errors\\nWrappedError\\np0\\n(S\\\'BatchGetDecorationsErrors(
{\\\\\\\'sold_counts_by_id\\\\\\\': IntegrityError(\\\\\\\'duplicate key value violates
unique constraint "auth_user_username_key"\\\\\\\\nDETAIL:  Key (username)=(test_user_0)
already exists.\\\\\\\\n\\\\\\\',)},)\\\'\\np1\\ntp2\\nRp3\\n(dp4\\nS\\\'traceback\\\'
\\np5\\ncgevent._tblib\\nunpickle_traceback...\')
```

...it's pretty ugly since we're viewing pickled data, but you can just about make out the real error, in this case an `IntegrityError` from the db

(I don't know why the traceback can't be unpickled in this case) 