### PR TITLE
better reporting of errors from subprocess

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -164,10 +164,11 @@ On the other hand, customised environment vars *will* be inherited by the subpro
             results = call_concurrently(1, func_to_test)
         assert results[0] == 'so special'
 
+.. _string-import-paths:
 
 Lastly, you can pass a string import path to a function rather than the function itself. The format is: ``'dotted module.path.to:function'`` (NOTE colon separates the name to import, after the dotted module path).
 
-This can be nice when you don't want to import the function itself in your test to pass it. But more importantly it is *essential* in some cases, such as when ``f`` is a decorated function whose decorator returns a new object (and ``functools.wraps`` was not used). In that situation we will not be able to introspect the import path from the function object's ``__module__`` (which will point to the decorator's module instead), so for those cases calling by string is *mandatory*.
+This can be nice when you don't want to import the function itself in your test to pass it. But more importantly it is *essential* in some cases, such as when ``f`` is a decorated function whose decorator returns a new object (and ``functools.wraps`` was not used). In that situation we will not be able to introspect the import path from the function object's ``__module__`` (which will point to the decorator's module instead), so for those cases calling by string is *mandatory*. (Celery tasks decorated with ``@app.task`` are an example which need to be called by string path)
 
 .. code:: python
 

--- a/django_concurrent_tests/__about__.py
+++ b/django_concurrent_tests/__about__.py
@@ -1,4 +1,4 @@
-__version__ = '0.6.0'
+__version__ = '0.6.1'
 
 
 if __name__ == '__main__':

--- a/django_concurrent_tests/management/commands/concurrent_call_wrapper.py
+++ b/django_concurrent_tests/management/commands/concurrent_call_wrapper.py
@@ -206,7 +206,15 @@ class Command(BaseCommand):
 
                 module_name, function_name = func_path.split(':')
                 module = import_module(module_name)
-                f = getattr(module, function_name)
+                try:
+                    f = getattr(module, function_name)
+                except AttributeError:
+                    print(
+                        "Could not import '{module}.{func}', you may need to use "
+                        "https://github.com/depop/django-concurrent-test-helper/#string-import-paths"
+                        .format(module=module_name, func=function_name)
+                    )
+                    raise
 
                 f_kwargs = deserialize(kwargs['kwargs'] or '{}')
 

--- a/django_concurrent_tests/utils.py
+++ b/django_concurrent_tests/utils.py
@@ -71,7 +71,7 @@ class ProcessManager(object):
             self.terminated = True
             thread.join()
 
-        logger.debug(self.stderr)
+        logger.error(self.stderr)
         return self.stdout
 
 


### PR DESCRIPTION
especially re `AttributeError: 'module' object has no attribute '<func name>'` errors

these are likely due to decorated functions e.g. Celery task which need to be imported via a string path (can't introspect via `func.__module__` due to replacement of original `func` by decorator)